### PR TITLE
challenges/3/go/otsudann

### DIFF
--- a/challenges/3-tipos-de-triangulo/go/otsudann/challenge.go
+++ b/challenges/3-tipos-de-triangulo/go/otsudann/challenge.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+    "fmt"
+    m "math"
+)
+
+func main(){
+  var ladosTriangulo = []float64{0.0, 0.0, 0.0}
+  var posicao int = 0
+  var ladoA float64 = 0.0
+  var ladoB float64 = 0.0
+  var ladoC float64 = 0.0
+
+  fmt.Println("Insira os tres lados de um triangulo separados por um espaço:")
+  fmt.Scan(&ladosTriangulo[0], &ladosTriangulo[1], &ladosTriangulo[2])
+
+  // Definir o maior valor como o lado A
+  for index, valor := range ladosTriangulo {
+    if valor >= ladoA {
+      ladoA = valor
+      posicao = index
+    }
+  } 
+
+  // Remover o valor de ladoA pela posicao do array
+  ladosTriangulo = RemoverIndex(ladosTriangulo, posicao)
+  ladoB = ladosTriangulo[0]
+  ladoC = ladosTriangulo[1]
+
+  if ladoA >= (ladoB + ladoC){
+    fmt.Println("NAO FORMA TRIANGULO")
+  }
+  if m.Pow(ladoA, 2) == (m.Pow(ladoB, 2) + m.Pow(ladoC, 2)){
+    fmt.Println("TRIANGULO RETANGULO")
+  }
+  if m.Pow(ladoA, 2) > (m.Pow(ladoB, 2) + m.Pow(ladoC, 2)){
+    fmt.Println("TRIANGULO OBTUSANGULO")
+  }
+  if m.Pow(ladoA, 2) < (m.Pow(ladoB, 2) + m.Pow(ladoC, 2)){
+    fmt.Println("TRIANGULO ACUTANGULO")
+  }
+  if ladoA == ladoB && ladoB == ladoC {
+    fmt.Println("TRIANGULO EQUILATERO")
+  }else if ladoA == ladoB || ladoB == ladoC || ladoC == ladoA {
+    fmt.Println("TRIANGULO ISOSCELES")
+  }
+}
+
+func RemoverIndex(s []float64, index int) []float64 {
+  return append(s[:index], s[index+1:]...)
+}

--- a/challenges/3-tipos-de-triangulo/go/otsudann/readme.md
+++ b/challenges/3-tipos-de-triangulo/go/otsudann/readme.md
@@ -1,0 +1,16 @@
+# Submissão de Exercicio
+
+**Exercicio:** 3-tipos-de-triangulo
+
+**Nickname:** otsudann
+
+**Nível Técnico:** intermediario
+
+**Dificuldade de Resolução:** Baixa
+
+**Como rodar o desafio**: 
+
+Use o comando abaixo: 
+```bash
+go run challenge.go
+```


### PR DESCRIPTION
Notei que o output necessario indicado no [readme](https://github.com/he4rt/he4rtoberfest-2022/blob/main/challenges/3-tipos-de-triangulo/readme.md) deste challenge precisa de uma pequena correção.

A Situação:
Nos é informado a necessidade de atribuir o **maior valor ao ladoA**:
> ...de modo que o lado A representa o maior dos 3 lados...

Então, quando verificamos o resultado dos lados "6.0 6.0 10.0", está ecrito que ele é um "TRIANGULO ACUTANGULO" e não "TRIANGULO OBTUSANGULO".

Exemplo se não ordenarmos os valores:
> A = 6^2 == 36 | B = 6^2 == 36 | C = 10^2 == 100
> "A == 36" não é maior que "B + C == 136", então é um triangulo ACUTANGULO

Exemplo se não ordenarmos os valores:
> A = 10^2 == 100 | B = 6^2 == 36 | C = 6^2 == 36
> "A == 100" é sim maior que "B + C == 72", então é um triangulo OBTUSANGULO

O mesmo acontece com a ultima entrada, dos valores "6.0 8.0 10.0" com resultado sendo "TRIANGULO RETANGULO" e não "NAO FORMA TRIANGULO".